### PR TITLE
Fix possible hanging issues

### DIFF
--- a/src/JPSoftworks.RecentFilesExtension/Program.cs
+++ b/src/JPSoftworks.RecentFilesExtension/Program.cs
@@ -12,7 +12,7 @@ namespace JPSoftworks.RecentFilesExtension;
 
 public static class Program
 {
-    [STAThread]
+    [MTAThread]
     public static async Task Main(string[] args)
     {
         if (args.Length > 0 && args[0] == "-RegisterProcessAsComServer")

--- a/src/JPSoftworks.RecentFilesExtension/Program.cs
+++ b/src/JPSoftworks.RecentFilesExtension/Program.cs
@@ -17,7 +17,7 @@ public static class Program
     {
         if (args.Length > 0 && args[0] == "-RegisterProcessAsComServer")
         {
-            await using ComServer server = new();
+            ComServer server = new();
             ManualResetEvent extensionDisposedEvent = new(false);
 
             // We are instantiating an extension instance once above, and returning it every time the callback in RegisterExtension below is called.
@@ -32,7 +32,7 @@ public static class Program
             extensionDisposedEvent.WaitOne();
 
             // Bye, bye
-            server.Stop();
+            server.UnsafeDispose();
         }
         else
         {


### PR DESCRIPTION
Switched to multithreaded apartment (MTA).  The internal COM server is now stopped without waiting for its safe disposal. This should slightly help with quiesce app hangs.

Resolves: #9