### PR TITLE
Upgrade JPSoftworks.CommandPalette.Extensions.Toolkit to 0.3.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
-    <PackageVersion Include="JPSoftworks.CommandPalette.Extensions.Toolkit" Version="0.3.0-preview.1" />
+    <PackageVersion Include="JPSoftworks.CommandPalette.Extensions.Toolkit" Version="0.3.0-preview.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0-preview.24508.2" />
     <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.2.0" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,17 +4,16 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
-    <PackageVersion Include="JPSoftworks.CommandPalette.Extensions.Toolkit" Version="0.0.2" />
-    <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.1.0" />
+    <PackageVersion Include="JPSoftworks.CommandPalette.Extensions.Toolkit" Version="0.3.0-preview.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0-preview.24508.2" />
+    <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.2.0" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.183" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.6.250205002" />
     <PackageVersion Include="Serilog" Version="4.2.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="Shmuelie.WinRTServer" Version="2.1.1" />
+    <PackageVersion Include="Shmuelie.WinRTServer" Version="2.2.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Drawing.Common" Version="9.0.4" />
     <PackageVersion Include="System.Text.Json" Version="9.0.3" />

--- a/src/JPSoftworks.RecentFilesExtension/JPSoftworks.RecentFilesExtension.csproj
+++ b/src/JPSoftworks.RecentFilesExtension/JPSoftworks.RecentFilesExtension.csproj
@@ -55,10 +55,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.CsWinRT" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="Microsoft.Web.WebView2" />
-    <PackageReference Include="Serilog" />
-    <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="System.Drawing.Common" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Shmuelie.WinRTServer" />
@@ -88,9 +85,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' != 'DEBUG' ">
-	  <IsAotCompatible>true</IsAotCompatible>
-	  <PublishTrimmed>true</PublishTrimmed>
-	  <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>false</PublishTrimmed>
+    <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -101,6 +97,12 @@
 
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ImplicitUsings>enable</ImplicitUsings>
+    
+    <IsAotCompatible>true</IsAotCompatible>
+
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
   </PropertyGroup>
 
   <Target Name="UpdateVersionFromManifest" BeforeTargets="BeforeBuild">

--- a/src/JPSoftworks.RecentFilesExtension/Program.cs
+++ b/src/JPSoftworks.RecentFilesExtension/Program.cs
@@ -4,9 +4,7 @@
 //
 // ------------------------------------------------------------
 
-using JPSoftworks.CommandPalette.Extensions.Toolkit.Helpers;
-using Shmuelie.WinRTServer;
-using Shmuelie.WinRTServer.CsWinRT;
+using JPSoftworks.CommandPalette.Extensions.Toolkit;
 
 namespace JPSoftworks.RecentFilesExtension;
 
@@ -15,30 +13,17 @@ public static class Program
     [MTAThread]
     public static async Task Main(string[] args)
     {
-        Logger.Initialize("JPSoftworks", "RecentFilesExtension");
-
-        if (args.Length > 0 && args[0] == "-RegisterProcessAsComServer")
+        await ExtensionHostRunner.RunAsync(args, new()
         {
-            ComServer server = new();
-            ManualResetEvent extensionDisposedEvent = new(false);
-
-            // We are instantiating an extension instance once above, and returning it every time the callback in RegisterExtension below is called.
-            // This makes sure that only one instance of SampleExtension is alive, which is returned every time the host asks for the IExtension object.
-            // If you want to instantiate a new instance each time the host asks, create the new instance inside the delegate.
-            RecentFilesExtension extensionInstance = new(extensionDisposedEvent);
-            server.RegisterClass<RecentFilesExtension, IExtension>(() => extensionInstance);
-            server.Start();
-
-            // This will make the main thread wait until the event is signaled by the extension class.
-            // Since we have single instance of the extension object, we exit as soon as it is disposed.
-            extensionDisposedEvent.WaitOne();
-
-            // Bye, bye
-            server.UnsafeDispose();
-        }
-        else
-        {
-            await StartupHelper.HandleDirectLaunchAsync();
-        }
+            PublisherMoniker = "JPSoftworks",
+            ProductMoniker = "RecentFilesExtension",
+            EnableEfficiencyMode = true,
+            ExtensionFactories = [
+                new DelegateExtensionFactory(extensionDisposedEvent => new RecentFilesExtension(extensionDisposedEvent))
+            ],
+#if DEBUG
+            IsDebug = true,
+#endif
+        });
     }
 }


### PR DESCRIPTION
Swiches to JPSoftworks.CommandPalette.Extensions.Toolkit 0.3.0 and starts using ExtensionHostRunner as host. This gives us new feature
- QoS Eco mode
- Handling Win32 app and system events (request to close the app or the end of user session)
- Shudown priority to ensure system closes host Command Palette first
- yet undiscovered bugs